### PR TITLE
update Link props

### DIFF
--- a/starter/components/card.js
+++ b/starter/components/card.js
@@ -4,7 +4,7 @@ import NextImage from "./image"
 
 const Card = ({ article }) => {
   return (
-    <Link as={`/article/${article.slug}`} href="/article/[id]">
+    <Link href={`/article/${article.slug}`}>
       <a className="uk-link-reset">
         <div className="uk-card uk-card-muted">
           <div className="uk-card-media-top">

--- a/starter/components/nav.js
+++ b/starter/components/nav.js
@@ -19,7 +19,7 @@ const Nav = ({ categories }) => {
             {categories.map((category) => {
               return (
                 <li key={category.id}>
-                  <Link as={`/category/${category.slug}`} href="/category/[id]">
+                  <Link href={`/category/${category.slug}`}>
                     <a className="uk-link-reset">{category.name}</a>
                   </Link>
                 </li>


### PR DESCRIPTION
This fixes a temporary 404 when a user clicks the link. The API was updated:

> as - Optional decorator for the path that will be shown in the browser URL bar. Before Next.js 9.5.3 this was used for dynamic routes, check our previous docs to see how it worked. Note: when this path differs from the one provided in href the previous href/as behavior is used as shown in the previous docs.

[Next Link Docs](https://nextjs.org/docs/api-reference/next/link)